### PR TITLE
Update case in links

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Beyond Enhancement Suite",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "manifest_version": 2,
   "description": " A suite of modules that make your D&D Beyond browsing experience better",
   "homepage_url": "https://github.com/josephwegner/bes",

--- a/src/inject/features/characterLinks.js
+++ b/src/inject/features/characterLinks.js
@@ -20,7 +20,7 @@
 
   function buildDOMElements (characters) {
     var cssHref = document.querySelectorAll("link[rel='stylesheet'][href*=compiled]")[0].href
-      var version = cssHref.match(/\/Content\/([0-9-]+)\//)[1]
+      var version = cssHref.match(/\/content\/([0-9-]+)\//)[1]
 
     characters.forEach((character) => {
       var wrapper = document.createElement('div')
@@ -34,7 +34,7 @@
       var avatar = document.createElement('img')
       var avaURL = character.avatar
       if (!avaURL) {
-        avaURL = `https://www.dndbeyond.com/Content/${version}/Skins/Waterdeep/images/characters/default-avatar.png`
+        avaURL = `https://www.dndbeyond.com/content/${version}/skins/waterdeep/images/characters/default-avatar.png`
       }
       avatar.setAttribute('src', avaURL)
 


### PR DESCRIPTION
D&D Beyond seems to have removed some capitals in their links. Update usage so the extension can work again.